### PR TITLE
Support multiple published banners and add management page

### DIFF
--- a/src/app/download/actions.ts
+++ b/src/app/download/actions.ts
@@ -1,57 +1,59 @@
 'use server';
 
-import { getFirestore, collection, query, where, getDocs, limit, Timestamp } from 'firebase/firestore';
+import { getFirestore, collection, query, where, getDocs, Timestamp } from 'firebase/firestore';
 import { app } from '@/lib/firebase';
 
 const db = getFirestore(app);
 
-type BannerResult = { 
-  name: string; 
-  banner: string; 
-  bannerFileName: string; 
-} | { error: string };
+type BannerData = {
+  name: string;
+  banner: string;
+  bannerFileName: string;
+};
 
+type BannerResult = { banners: BannerData[] } | { error: string };
 
-export async function getBannerForPhone(phone: string): Promise<BannerResult> {
+export async function getBannersForPhone(phone: string): Promise<BannerResult> {
   try {
-    const q = query(
-        collection(db, 'sharedBanners'), 
-        where('phone', '==', phone),
-        limit(1)
-    );
+    const q = query(collection(db, 'sharedBanners'), where('phone', '==', phone));
     const querySnapshot = await getDocs(q);
 
     if (querySnapshot.empty) {
       return { error: 'No banner is available for this phone number.' };
     }
 
-    const docData = querySnapshot.docs[0].data();
-    
-    // Check for suspension
-    if (docData.status === 'suspended') {
-        return { error: 'Account Suspended. Please contact support.' };
-    }
+    const banners: BannerData[] = [];
+    querySnapshot.forEach(docSnap => {
+      const docData = docSnap.data();
 
-    // Check for expiration
-    const createdAt = (docData.createdAt as Timestamp)?.toDate();
-    const duration = docData.duration; // in days
+      if (docData.status === 'suspended') {
+        return;
+      }
 
-    if (createdAt && typeof duration === 'number') {
+      const createdAt = (docData.createdAt as Timestamp)?.toDate();
+      const duration = docData.duration;
+      if (createdAt && typeof duration === 'number') {
         const expirationDate = new Date(createdAt);
         expirationDate.setDate(expirationDate.getDate() + duration);
         if (new Date() > expirationDate) {
-            return { error: 'Plan Expired. Contact Support.' };
+          return;
         }
+      }
+
+      banners.push({
+        name: docData.shopName as string,
+        banner: docData.bannerDataUri as string,
+        bannerFileName: (docData.bannerFileName as string) || 'banner',
+      });
+    });
+
+    if (banners.length === 0) {
+      return { error: 'No banner is available for this phone number.' };
     }
 
-    return {
-        name: docData.shopName,
-        banner: docData.bannerDataUri,
-        bannerFileName: docData.bannerFileName || 'banner',
-    };
-
+    return { banners };
   } catch (error) {
-    console.error("Error fetching banner data:", error);
+    console.error('Error fetching banner data:', error);
     return { error: 'An unexpected error occurred while retrieving the banner.' };
   }
 }

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -429,8 +429,17 @@ export default function EditorPage() {
         setIsSending(false);
         return;
       }
+      if (!bannerImage) {
+        toast({
+          title: 'No Banner Image',
+          description: 'Please upload a banner image before sharing.',
+          variant: 'destructive',
+        });
+        setIsSending(false);
+        return;
+      }
 
-      const results = await shareBannersByLink(shopsWithBanners);
+      const results = await shareBannersByLink(bannerImage, shopsWithBanners);
       const successCount = results.filter(r => r.success).length;
       const errorCount = results.length - successCount;
 

--- a/src/app/published/actions.ts
+++ b/src/app/published/actions.ts
@@ -1,0 +1,34 @@
+'use server';
+
+import { getFirestore, collection, getDocs, deleteDoc, doc, query, where, writeBatch } from 'firebase/firestore';
+import { app } from '@/lib/firebase';
+
+const db = getFirestore(app);
+
+export async function getPublishedBanners() {
+  const snapshot = await getDocs(collection(db, 'publishedBanners'));
+  return snapshot.docs.map(docSnap => {
+    const data = docSnap.data();
+    return {
+      id: docSnap.id,
+      banner: data.baseBannerDataUri as string,
+      createdAt: data.createdAt?.toDate().toISOString() || null,
+    };
+  });
+}
+
+export async function deletePublishedBanner(id: string) {
+  try {
+    await deleteDoc(doc(db, 'publishedBanners', id));
+    const q = query(collection(db, 'sharedBanners'), where('baseBannerId', '==', id));
+    const snapshot = await getDocs(q);
+    const batch = writeBatch(db);
+    snapshot.forEach(docSnap => batch.delete(docSnap.ref));
+    await batch.commit();
+    return { success: true };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+    console.error('Error deleting published banner:', error);
+    return { success: false, error: errorMessage };
+  }
+}

--- a/src/app/published/page.tsx
+++ b/src/app/published/page.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Image from 'next/image';
+import { getPublishedBanners, deletePublishedBanner } from './actions';
+import { Button } from '@/components/ui/button';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+
+interface PublishedBanner {
+  id: string;
+  banner: string;
+  createdAt: string | null;
+}
+
+export default function PublishedPage() {
+  const [banners, setBanners] = useState<PublishedBanner[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      const data = await getPublishedBanners();
+      setBanners(data);
+      setLoading(false);
+    })();
+  }, []);
+
+  const handleDelete = async (id: string) => {
+    const result = await deletePublishedBanner(id);
+    if (result.success) {
+      setBanners(prev => prev.filter(b => b.id !== id));
+    }
+  };
+
+  if (loading) {
+    return <div className="p-4">Loading...</div>;
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Published Banners</h1>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {banners.map(b => (
+          <Card key={b.id}>
+            <CardHeader>
+              <CardTitle>
+                {b.createdAt ? new Date(b.createdAt).toLocaleString() : 'Unknown date'}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <div className="relative aspect-[1200/630] w-full overflow-hidden rounded-md border">
+                <Image src={b.banner} alt="Published banner" fill style={{ objectFit: 'contain' }} />
+              </div>
+              <Button variant="destructive" onClick={() => handleDelete(b.id)}>
+                Delete
+              </Button>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -43,6 +43,9 @@ export function Header({ onClearBanner, onDeleteBanner }: HeaderProps) {
             <Users className="mr-2" /> Manage Shops
           </Link>
         </Button>
+        <Button asChild>
+          <Link href="/published">Published Banners</Link>
+        </Button>
          <Button variant="outline" onClick={onClearBanner}>
           <Trash className="mr-2" /> Clear Editor
         </Button>


### PR DESCRIPTION
## Summary
- keep all generated banners by recording base banner in Firestore
- add Published Banners page to review and delete published base images
- allow download page to show and save multiple banners per phone

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt, no lint executed)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ba87ea45f8832fbe50854a17c978d0